### PR TITLE
Fixing verilator PROCASSWIRE Error, adding focal CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,23 @@
+jobs:
+  include:
+    - dist: bionic
+      os: linux
+    - dist: focal
+      os: linux
+      
 language: c
-sudo: enabled
-dist: 
-  - bionic
-  - focal
-
 notifications:
   email: true
-
 before_install:
-  - sudo apt-get install build-essential cmake iverilog tk binutils-msp430 gcc-msp430 msp430-libc msp430mcu expect-dev verilator -y
+- sudo apt-get install build-essential cmake iverilog tk binutils-msp430 gcc-msp430 msp430-libc msp430mcu expect-dev verilator -y
 
 install:
-  - mkdir build && cd build && cmake .. && cd ..
+- mkdir build && cd build && cmake .. && cd ..
 
 script:
-  - cd core/sim/rtl_sim/run/
-  - ./$TARGET
+- cd core/sim/rtl_sim/run/
+- ./$TARGET
 
 env:
   - TARGET=run_all
   - TARGET=run_all_sancus
-
-jobs: # On focal we exclude the long run
-  exclude:
-  - dist: focal
-    env: TARGET=run_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ jobs:
   include:
     - dist: focal
       os: linux
-      env: TARGET=run_all_sancus
+      script: ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
 jobs: # Add jobs that only compile but do not run the tests.
   include:
     - name: "Only compile, bionic"
-      script: cmake --build .
+      script: cd build && cmake --build .
     - name: "Only compile, focal"
       dist: focal
       os: linux
-      script: cmake --build .
+      script: cd build && cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
-jobs:
-  include:
-    - dist: bionic
-      os: linux
-    - dist: focal
-      os: linux
-      
 language: c
+
+dist: bionic
+os: linux
+
 notifications:
   email: true
+
 before_install:
 - sudo apt-get install build-essential cmake iverilog tk binutils-msp430 gcc-msp430 msp430-libc msp430mcu expect-dev verilator -y
 
@@ -21,3 +19,9 @@ script:
 env:
   - TARGET=run_all
   - TARGET=run_all_sancus
+
+jobs:
+  include:
+    - dist: focal
+      os: linux
+      env: TARGET=run_all_sancus

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,11 @@ env:
   - TARGET=run_all
   - TARGET=run_all_sancus
 
-jobs:
+jobs: # Add jobs that only compile but do not run the tests.
   include:
-    - dist: focal
+    - name: "Only compile, bionic"
+      script: cmake --build .
+    - name: "Only compile, focal"
+      dist: focal
       os: linux
-      script: ls
+      script: cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 sudo: enabled
-dist: trusty
+dist: 
+  - bionic
+  - focal
 
 notifications:
   email: true
@@ -18,3 +20,8 @@ script:
 env:
   - TARGET=run_all
   - TARGET=run_all_sancus
+
+jobs: # On focal we exclude the long run
+  exclude:
+  - dist: focal
+    env: TARGET=run_all

--- a/core/bench/verilog/file_io.v
+++ b/core/bench/verilog/file_io.v
@@ -8,9 +8,9 @@ module file_io (
 `ifdef VERILATOR
     input  wire [7:0]  fio_din,
     input  wire        fio_dready,
-    output wire [7:0]  fio_dout,
-    output wire        fio_dnxt,
-    output wire        fio_dout_rdy,
+    output reg [7:0]   fio_dout,
+    output reg         fio_dnxt,
+    output reg         fio_dout_rdy,
 `endif
     input  wire        puc_rst
 );


### PR DESCRIPTION
This fixes the Verilator PROCASSWIRE error that was introduced in the latest version. It states "Procedural assignment to wire, perhaps intended var (IEEE 1800-2017 6.5)".

I also added a Travis CI addition to run on focal and bionic while only bionic performs the run_all tests.