### PR TITLE
Improve IRQ real-time compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 os: linux
 
 notifications:
-  email: true
+  email: false
 
 before_install:
 - sudo apt-get install build-essential cmake iverilog tk binutils-msp430 gcc-msp430 msp430-libc msp430mcu expect-dev verilator -y

--- a/core/bench/verilog/irq_macros.v
+++ b/core/bench/verilog/irq_macros.v
@@ -56,10 +56,11 @@
 
 `define CHK_IRQ_REGS( str, spVal, retiAddr, irqStatus) \
     `CHK_IRQ_REGS_SP( str, spVal, retiAddr, irqStatus, 1'b1 )
-   
+
+// protected interrupts are written to SSA starting at sm_secret_end-4
 `define CHK_IRQ_STACK_R15( str, pc, sr, r15Val ) \
       /*$display({"checking stack memory ", str});*/ \
-      if (mem268 !==pc)        tb_error({"====== STACK MEMORY PC (", str, ") ====="});  \
+      if (mem26A !==pc)        tb_error({"====== STACK MEMORY PC (", str, ") ====="});  \
       if (mem266 !==sr)        tb_error({"====== STACK MEMORY SR (", str, ") ====="});  \
       if (mem264 !==r15Val)    tb_error({"====== STACK MEMORY r15 (", str, ") ====="}); \
       if (mem262 !==`R14_VAL)  tb_error({"====== STACK MEMORY r14 (", str, ") ====="}); \
@@ -76,3 +77,9 @@
 
 `define CHK_IRQ_STACK( str, pc, sr ) \
     `CHK_IRQ_STACK_R15( str, pc, sr, `R15_VAL )
+
+// Unprotected interrupts are written to stack starting at stack_base
+`define CHK_IRQ_STACK_UNPROTECTED( str, pc, sr ) \
+      /*$display({"checking stack memory ", str});*/ \
+      if (mem23E !==pc)        tb_error({"====== STACK MEMORY PC (", str, ") ====="});  \
+      if (mem23C !==sr)        tb_error({"====== STACK MEMORY SR (", str, ") ====="});

--- a/core/bench/verilog/irq_macros.v
+++ b/core/bench/verilog/irq_macros.v
@@ -59,20 +59,20 @@
    
 `define CHK_IRQ_STACK_R15( str, pc, sr, r15Val ) \
       /*$display({"checking stack memory ", str});*/ \
-      if (mem25E !==pc)        tb_error({"====== STACK MEMORY PC (", str, ") ====="});  \
-      if (mem25C !==sr)        tb_error({"====== STACK MEMORY SR (", str, ") ====="});  \
-      if (mem25A !==r15Val)    tb_error({"====== STACK MEMORY r15 (", str, ") ====="}); \
-      if (mem258 !==`R14_VAL)  tb_error({"====== STACK MEMORY r14 (", str, ") ====="}); \
-      if (mem256 !==`R13_VAL)  tb_error({"====== STACK MEMORY r13 (", str, ") ====="}); \
-      if (mem254 !==`R12_VAL)  tb_error({"====== STACK MEMORY r12 (", str, ") ====="}); \
-      if (mem252 !==`R11_VAL)  tb_error({"====== STACK MEMORY r11 (", str, ") ====="}); \
-      if (mem250 !==`R10_VAL)  tb_error({"====== STACK MEMORY r10 (", str, ") ====="}); \
-      if (mem24E !==`R9_VAL)   tb_error({"====== STACK MEMORY r9 (", str, ") ====="});  \
-      if (mem24C !==`R8_VAL)   tb_error({"====== STACK MEMORY r8 (", str, ") ====="});  \
-      if (mem24A !==`R7_VAL)   tb_error({"====== STACK MEMORY r7 (", str, ") ====="});  \
-      if (mem248 !==`R6_VAL)   tb_error({"====== STACK MEMORY r6 (", str, ") ====="});  \
-      if (mem246 !==`R5_VAL)   tb_error({"====== STACK MEMORY r5 (", str, ") ====="});  \
-      if (mem244 !==`R4_VAL)   tb_error({"====== STACK MEMORY r4 (", str, ") ====="});
+      if (mem268 !==pc)        tb_error({"====== STACK MEMORY PC (", str, ") ====="});  \
+      if (mem266 !==sr)        tb_error({"====== STACK MEMORY SR (", str, ") ====="});  \
+      if (mem264 !==r15Val)    tb_error({"====== STACK MEMORY r15 (", str, ") ====="}); \
+      if (mem262 !==`R14_VAL)  tb_error({"====== STACK MEMORY r14 (", str, ") ====="}); \
+      if (mem260 !==`R13_VAL)  tb_error({"====== STACK MEMORY r13 (", str, ") ====="}); \
+      if (mem25E !==`R12_VAL)  tb_error({"====== STACK MEMORY r12 (", str, ") ====="}); \
+      if (mem25C !==`R11_VAL)  tb_error({"====== STACK MEMORY r11 (", str, ") ====="}); \
+      if (mem25A !==`R10_VAL)  tb_error({"====== STACK MEMORY r10 (", str, ") ====="}); \
+      if (mem258 !==`R9_VAL)   tb_error({"====== STACK MEMORY r9 (", str, ") ====="});  \
+      if (mem256 !==`R8_VAL)   tb_error({"====== STACK MEMORY r8 (", str, ") ====="});  \
+      if (mem254 !==`R7_VAL)   tb_error({"====== STACK MEMORY r7 (", str, ") ====="});  \
+      if (mem252 !==`R6_VAL)   tb_error({"====== STACK MEMORY r6 (", str, ") ====="});  \
+      if (mem250 !==`R5_VAL)   tb_error({"====== STACK MEMORY r5 (", str, ") ====="});  \
+      if (mem24E !==`R4_VAL)   tb_error({"====== STACK MEMORY r4 (", str, ") ====="});
 
 `define CHK_IRQ_STACK( str, pc, sr ) \
     `CHK_IRQ_STACK_R15( str, pc, sr, `R15_VAL )

--- a/core/bench/verilog/msp_debug.v
+++ b/core/bench/verilog/msp_debug.v
@@ -168,8 +168,9 @@ always @(e_state_bin)
       5'h10   : e_state =  "IRQ_PRE";
       5'h11   : e_state =  "IRQ_EXT_0";
       5'h12   : e_state =  "IRQ_EXT_1";
-      5'h13   : e_state =  "IRQ_SSA_RD";
-      5'h14   : e_state =  "IRQ_SP_WR";
+      5'h13   : e_state =  "IRQ_SSA_RD_1";
+      5'h14   : e_state =  "IRQ_SSA_RD_2";
+      5'h15   : e_state =  "IRQ_SP_WR";
       default : e_state =  "xxxx";
     endcase
 

--- a/core/bench/verilog/msp_debug.v
+++ b/core/bench/verilog/msp_debug.v
@@ -168,7 +168,7 @@ always @(e_state_bin)
       5'h10   : e_state =  "IRQ_PRE";
       5'h11   : e_state =  "IRQ_EXT_0";
       5'h12   : e_state =  "IRQ_EXT_1";
-      5'h13   : e_state =  "IRQ_SP_RD";
+      5'h13   : e_state =  "IRQ_SSA_RD";
       5'h14   : e_state =  "IRQ_SP_WR";
       default : e_state =  "xxxx";
     endcase

--- a/core/bench/verilog/sancus-def.v
+++ b/core/bench/verilog/sancus-def.v
@@ -12,6 +12,7 @@ wire        crypto_start        = dut.execution_unit_0.crypto.start;
 wire        crypto_busy         = dut.execution_unit_0.crypto.busy;
 
 wire [15:0] stack_guard         = dut.execution_unit_0.register_file_0.stack_guard;
+wire        r2_z                = dut.execution_unit_0.register_file_0.r2_z;
 
 wire [15:0] sm_current_id       = dut.execution_unit_0.spm_control_0.spm_current_id;
 wire [15:0] sm_prev_id          = dut.execution_unit_0.spm_control_0.spm_prev_id;

--- a/core/rtl/verilog/crypto/crypto_control.v
+++ b/core/rtl/verilog/crypto/crypto_control.v
@@ -3,6 +3,7 @@
 module crypto_control(
     input  wire                    clk,
     input  wire                    reset,
+    input  wire                    irq_pnd,
     input  wire                    start,
     input  wire                    cmd_key,
     input  wire                    cmd_disable,
@@ -40,7 +41,10 @@ module crypto_control(
     output reg              [15:0] reg_data_out,
     output reg                     sm_key_write,
     output wire [KEY_IDX_SIZE-1:0] sm_key_idx,
-    output reg              [15:0] data_out
+    output reg              [15:0] data_out,
+    output reg                     stat_z,
+    output reg                     stat_wr,
+    output reg                     sm_cancel
 );
 
 parameter KEY_IDX_SIZE = -1;
@@ -125,7 +129,12 @@ localparam [STATE_SIZE-1:0] IDLE              =  0,
 
 reg [STATE_SIZE-1:0] state, next_state;
 
+wire irq_state_ok = state!=IDLE & state!=CHECK_SM & state!=FAIL & state!=SUCCESS;
+
 always @(*)
+    /* fail the currently executing crypto instruction on IRQ arrival; this
+    should also stop the crypto unit in case of an SM memory violation */
+    if (irq_pnd & irq_state_ok) next_state = FAIL; else
     case (state)
         IDLE:              next_state = ~start      ? IDLE              :
                                         cmd_key     ? ENABLE_SM         :
@@ -258,6 +267,9 @@ begin
     sm_key_write = 0;
     sm_request = 0;
     load_key_block = 0;
+    stat_z = 0;
+    stat_wr = 0;
+    sm_cancel = 0;
 
     case (next_state)
         IDLE:
@@ -663,11 +675,17 @@ begin
             set_reg_write = 1;
             dest_reg_val = 16'h8000;
             reg_data = 16'h0;
+            /* set zero flag to distinguish IRQ from verification failure */
+            stat_z = irq_pnd;
+            stat_wr = 1;
+            sm_cancel = cmd_key;
         end
 
         SUCCESS:
         begin
             set_reg_write = 1;
+            stat_z = 0;
+            stat_wr = 1;
             dest_reg_val = cmd_disable ? 16'h0001 : 16'h8000;
             sm_request = `SM_REQ_ID;
             reg_data = return_id   ? sm_data    :

--- a/core/rtl/verilog/crypto/crypto_control.v
+++ b/core/rtl/verilog/crypto/crypto_control.v
@@ -865,6 +865,8 @@ always @(posedge clk)
         $display("Vendor key: %h", key);
     else if (state == SUCCESS & cmd_key)
         $display("SM key: %h", key);
+    else if (stat_wr && stat_z)
+        $display("\tCrypto IRQ @0x%h", pc);
 
 // module instantiations *******************************************************
 wire        wrap_busy;

--- a/core/rtl/verilog/omsp_execution_unit.v
+++ b/core/rtl/verilog/omsp_execution_unit.v
@@ -329,7 +329,7 @@ omsp_register_file register_file_0 (
 
 wire src_reg_pc_sel     = (e_state==`E_IRQ_PRE);
 
-wire src_sm_req_sel     = irq_prepare_sp_wr   | (e_state==`E_IRQ_SSA_RD) |
+wire src_sm_req_sel     = irq_prepare_sp_wr   | (e_state==`E_IRQ_SSA_RD_1) |
                           (e_state==`E_IRQ_4) | (irq_exec & sm_data_select_valid);
 
 wire src_reg_src_sel    =  (e_state==`E_IRQ_1)                    |
@@ -388,7 +388,7 @@ wire dst_mdb_in_bw_sel  = ((e_state==`E_DST_WR) &   inst_so[`RETI]) |
 
 wire dst_fffe_sel       = (e_state==`E_IRQ_PRE)                         |
                           irq_sp_upd                                    |
-                          irq_prepare_sp_wr | (e_state==`E_IRQ_SSA_RD)   |
+                          irq_prepare_sp_wr | (e_state==`E_IRQ_SSA_RD_1)   |
                           ((e_state==`E_DST_RD) & (inst_so[`PUSH] | inst_so[`CALL]) & ~inst_so[`RETI]) |
                           ((e_state==`E_SRC_AD) & (inst_so[`PUSH] | inst_so[`CALL]) & inst_as[`IDX]) |
                           ((e_state==`E_SRC_RD) & (inst_so[`PUSH] | inst_so[`CALL]) & (inst_as[`INDIR] | inst_as[`INDIR_I]) & inst_src[1]);
@@ -443,7 +443,7 @@ wire        irq_sp_mb_wr    = ((e_state==`E_IRQ_1)    |
 
 wire        irq_mb_wr       = irq_sp_mb_wr | (e_state==`E_IRQ_SP_WR);
 
-wire        irq_mb_rd       = (e_state==`E_IRQ_SSA_RD);
+wire        irq_mb_rd       = (e_state==`E_IRQ_SSA_RD_1);
 
 wire        irq_mdb_out_bis = ((e_state==`E_IRQ_EXT_1) & inst_src[1])? 1'b1 : 1'b0;
 
@@ -637,7 +637,7 @@ wire sm_busy = crypto_busy;
 wire  [2:0] crypto_sm_request;
 wire [15:0] crypto_sm_data_select;
 wire        crypto_sm_data_select_type;
-wire        irq_secret_end_select   = (e_state==`E_IRQ_EXT_0) | (e_state==`E_IRQ_SSA_RD);
+wire        irq_secret_end_select   = (e_state==`E_IRQ_EXT_0) | (e_state==`E_IRQ_SSA_RD_1);
 wire        irq_reti_addr_select    = (e_state==`E_IRQ_4) | irq_exec;
 assign sm_request          = irq_secret_end_select  ? `SM_REQ_SECEND     :
                              irq_reti_addr_select   ? `SM_REQ_PUBSTART   : crypto_sm_request;

--- a/core/rtl/verilog/omsp_execution_unit.v
+++ b/core/rtl/verilog/omsp_execution_unit.v
@@ -494,7 +494,7 @@ wire        mclk_mdb_out_nxt = mclk;
 always @(posedge mclk_mdb_out_nxt or posedge puc_rst)
   if (puc_rst)                                        mdb_out_nxt <= 16'h0000;
   else if (e_state==`E_DST_RD)                        mdb_out_nxt <= pc_nxt;
-  else if (e_state==`E_IRQ_SP_WR)                     mdb_out_nxt <= r1;
+  else if (e_state==`E_IRQ_SP_WR)                     mdb_out_nxt <= r1 | 16'h0001;
 `ifdef CLOCK_GATING
   else                                                mdb_out_nxt <= alu_out;
 `else

--- a/core/rtl/verilog/omsp_execution_unit.v
+++ b/core/rtl/verilog/omsp_execution_unit.v
@@ -329,7 +329,7 @@ omsp_register_file register_file_0 (
 
 wire src_reg_pc_sel     = (e_state==`E_IRQ_PRE);
 
-wire src_sm_req_sel     = irq_prepare_sp_wr   | (e_state==`E_IRQ_SP_RD) |
+wire src_sm_req_sel     = irq_prepare_sp_wr   | (e_state==`E_IRQ_SSA_RD) |
                           (e_state==`E_IRQ_4) | (irq_exec & sm_data_select_valid);
 
 wire src_reg_src_sel    =  (e_state==`E_IRQ_1)                    |
@@ -388,7 +388,7 @@ wire dst_mdb_in_bw_sel  = ((e_state==`E_DST_WR) &   inst_so[`RETI]) |
 
 wire dst_fffe_sel       = (e_state==`E_IRQ_PRE)                         |
                           irq_sp_upd                                    |
-                          irq_prepare_sp_wr | (e_state==`E_IRQ_SP_RD)   |
+                          irq_prepare_sp_wr | (e_state==`E_IRQ_SSA_RD)   |
                           ((e_state==`E_DST_RD) & (inst_so[`PUSH] | inst_so[`CALL]) & ~inst_so[`RETI]) |
                           ((e_state==`E_SRC_AD) & (inst_so[`PUSH] | inst_so[`CALL]) & inst_as[`IDX]) |
                           ((e_state==`E_SRC_RD) & (inst_so[`PUSH] | inst_so[`CALL]) & (inst_as[`INDIR] | inst_as[`INDIR_I]) & inst_src[1]);
@@ -443,7 +443,7 @@ wire        irq_sp_mb_wr    = ((e_state==`E_IRQ_1)    |
 
 wire        irq_mb_wr       = irq_sp_mb_wr | (e_state==`E_IRQ_SP_WR);
 
-wire        irq_mb_rd       = (e_state==`E_IRQ_SP_RD);
+wire        irq_mb_rd       = (e_state==`E_IRQ_SSA_RD);
 
 wire        irq_mdb_out_bis = ((e_state==`E_IRQ_EXT_1) & inst_src[1])? 1'b1 : 1'b0;
 
@@ -637,7 +637,7 @@ wire sm_busy = crypto_busy;
 wire  [2:0] crypto_sm_request;
 wire [15:0] crypto_sm_data_select;
 wire        crypto_sm_data_select_type;
-wire        irq_secret_end_select   = (e_state==`E_IRQ_EXT_0) | (e_state==`E_IRQ_SP_RD);
+wire        irq_secret_end_select   = (e_state==`E_IRQ_EXT_0) | (e_state==`E_IRQ_SSA_RD);
 wire        irq_reti_addr_select    = (e_state==`E_IRQ_4) | irq_exec;
 assign sm_request          = irq_secret_end_select  ? `SM_REQ_SECEND     :
                              irq_reti_addr_select   ? `SM_REQ_PUBSTART   : crypto_sm_request;

--- a/core/rtl/verilog/omsp_frontend.v
+++ b/core/rtl/verilog/omsp_frontend.v
@@ -236,7 +236,7 @@ parameter E_DST_WR2   = `E_DST_WR2;
 parameter E_IRQ_PRE   = `E_IRQ_PRE;
 parameter E_IRQ_EXT_0 = `E_IRQ_EXT_0;
 parameter E_IRQ_EXT_1 = `E_IRQ_EXT_1;
-parameter E_IRQ_SP_RD = `E_IRQ_SP_RD;
+parameter E_IRQ_SSA_RD = `E_IRQ_SSA_RD;
 parameter E_IRQ_SP_WR = `E_IRQ_SP_WR;
 
 
@@ -961,7 +961,7 @@ always @(*)
       E_IDLE     : e_state_nxt =  e_first_state;
 
       /* IRQ_0-3: push SR/PC */
-      E_IRQ_PRE  : e_state_nxt =  exec_sm           ? E_IRQ_SP_RD : E_IRQ_0;
+      E_IRQ_PRE  : e_state_nxt =  exec_sm           ? E_IRQ_SSA_RD : E_IRQ_0;
       E_IRQ_0    : e_state_nxt =  E_IRQ_1;
       E_IRQ_1    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_2;
       E_IRQ_2    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_3;
@@ -979,7 +979,7 @@ always @(*)
                                   ~exec_sm)         ? E_IRQ_4     : E_IRQ_EXT_0;
 
       /* IRQ_SP: store SP in SM secret data */
-      E_IRQ_SP_RD: e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_SP_WR;
+      E_IRQ_SSA_RD: e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_SP_WR;
       E_IRQ_SP_WR: e_state_nxt =  E_IRQ_0;
 
       /* IRQ_4: vector to ISR */

--- a/core/rtl/verilog/omsp_frontend.v
+++ b/core/rtl/verilog/omsp_frontend.v
@@ -236,7 +236,8 @@ parameter E_DST_WR2   = `E_DST_WR2;
 parameter E_IRQ_PRE   = `E_IRQ_PRE;
 parameter E_IRQ_EXT_0 = `E_IRQ_EXT_0;
 parameter E_IRQ_EXT_1 = `E_IRQ_EXT_1;
-parameter E_IRQ_SSA_RD = `E_IRQ_SSA_RD;
+parameter E_IRQ_SSA_RD_1 = `E_IRQ_SSA_RD_1;
+parameter E_IRQ_SSA_RD_2 = `E_IRQ_SSA_RD_2;
 parameter E_IRQ_SP_WR = `E_IRQ_SP_WR;
 
 
@@ -961,7 +962,7 @@ always @(*)
       E_IDLE     : e_state_nxt =  e_first_state;
 
       /* IRQ_0-3: push SR/PC */
-      E_IRQ_PRE  : e_state_nxt =  exec_sm           ? E_IRQ_SSA_RD : E_IRQ_0;
+      E_IRQ_PRE  : e_state_nxt =  exec_sm           ? E_IRQ_SSA_RD_1 : E_IRQ_0;
       E_IRQ_0    : e_state_nxt =  E_IRQ_1;
       E_IRQ_1    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_2;
       E_IRQ_2    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_3;
@@ -979,7 +980,8 @@ always @(*)
                                   ~exec_sm)         ? E_IRQ_4     : E_IRQ_EXT_0;
 
       /* IRQ_SP: store SP in SM secret data */
-      E_IRQ_SSA_RD: e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_SP_WR;
+      E_IRQ_SSA_RD_1: e_state_nxt =  E_IRQ_SSA_RD_2;
+      E_IRQ_SSA_RD_2: e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_SP_WR;
       E_IRQ_SP_WR: e_state_nxt =  E_IRQ_0;
 
       /* IRQ_4: vector to ISR */

--- a/core/rtl/verilog/omsp_frontend.v
+++ b/core/rtl/verilog/omsp_frontend.v
@@ -81,6 +81,7 @@ module  omsp_frontend (
     prev_inst_pc,
     irq_num,
     irq_detect,
+    irq_pnd,
 
 // INPUTs
     cpu_en_s,                      // Enable CPU code execution (synchronous)
@@ -144,6 +145,7 @@ output       [15:0] current_inst_pc;
 output       [15:0] prev_inst_pc;
 output        [3:0] irq_num;
 output              irq_detect;
+output              irq_pnd;
 
 // INPUTs
 //=========

--- a/core/rtl/verilog/omsp_frontend.v
+++ b/core/rtl/verilog/omsp_frontend.v
@@ -961,7 +961,7 @@ always @(*)
       E_IDLE     : e_state_nxt =  e_first_state;
 
       /* IRQ_0-3: push SR/PC */
-      E_IRQ_PRE  : e_state_nxt =  E_IRQ_0;
+      E_IRQ_PRE  : e_state_nxt =  exec_sm           ? E_IRQ_SP_RD : E_IRQ_0;
       E_IRQ_0    : e_state_nxt =  E_IRQ_1;
       E_IRQ_1    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_2;
       E_IRQ_2    : e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_3;
@@ -973,14 +973,14 @@ always @(*)
 
       /* IRQ_EXT: push GP registers */
       E_IRQ_EXT_0: e_state_nxt =  sm_irq            ? E_IRQ_4     :
-                                  inst_src[1]       ? E_IRQ_SP_RD : E_IRQ_EXT_1;
+                                  inst_src[1]       ? E_IRQ_4     : E_IRQ_EXT_1;
       E_IRQ_EXT_1: e_state_nxt =  sm_irq |
                                   (inst_src[1] &
                                   ~exec_sm)         ? E_IRQ_4     : E_IRQ_EXT_0;
 
       /* IRQ_SP: store SP in SM secret data */
       E_IRQ_SP_RD: e_state_nxt =  sm_irq            ? E_IRQ_4     : E_IRQ_SP_WR;
-      E_IRQ_SP_WR: e_state_nxt =  E_IRQ_4;
+      E_IRQ_SP_WR: e_state_nxt =  E_IRQ_0;
 
       /* IRQ_4: vector to ISR */
       E_IRQ_4    : e_state_nxt =  E_EXEC;

--- a/core/rtl/verilog/omsp_register_file.v
+++ b/core/rtl/verilog/omsp_register_file.v
@@ -71,6 +71,8 @@ module  omsp_register_file (
 // INPUTs
     alu_stat,                     // ALU Status {V,N,Z,C}
     alu_stat_wr,                  // ALU Status write {V,N,Z,C}
+    crypto_stat_z,
+    crypto_stat_wr,
     inst_bw,                      // Decoded Inst: byte width
     inst_dest,                    // Register destination selection
     inst_src,                     // Register source selection
@@ -117,6 +119,8 @@ output              sp_overflow;
 //=========
 input         [3:0] alu_stat;     // ALU Status {V,N,Z,C}
 input         [3:0] alu_stat_wr;  // ALU Status write {V,N,Z,C}
+input               crypto_stat_z;
+input               crypto_stat_wr;
 input               inst_bw;      // Decoded Inst: byte width
 input        [15:0] inst_dest;    // Register destination selection
 input        [15:0] inst_src;     // Register source selection
@@ -225,7 +229,8 @@ wire        r2_wr  = (inst_dest[2] & reg_dest_wr) | reg_sr_wr;
 `ifdef CLOCK_GATING                                                              //      -- WITH CLOCK GATING --
 wire        r2_c   = alu_stat_wr[0] ? alu_stat[0]          : reg_dest_val_in[0]; // C
 
-wire        r2_z   = alu_stat_wr[1] ? alu_stat[1]          : reg_dest_val_in[1]; // Z
+wire        r2_z   = alu_stat_wr[1] ? alu_stat[1]          :
+                     crypto_stat_wr ? crypto_stat_z        : reg_dest_val_in[1]; // Z
 
 wire        r2_n   = alu_stat_wr[2] ? alu_stat[2]          : reg_dest_val_in[2]; // N
 
@@ -233,7 +238,7 @@ wire  [7:3] r2_nxt = r2_wr          ? reg_dest_val_in[7:3] : r2[7:3];
 
 wire        r2_v   = alu_stat_wr[3] ? alu_stat[3]          : reg_dest_val_in[8]; // V
 
-wire        r2_en  = |alu_stat_wr | r2_wr | reg_sr_clr;
+wire        r2_en  = |alu_stat_wr | r2_wr | reg_sr_clr | crypto_stat_wr;
 wire        mclk_r2;
 omsp_clock_gate clock_gate_r2 (.gclk(mclk_r2),
                                .clk (mclk), .enable(r2_en), .scan_enable(scan_enable));
@@ -243,6 +248,7 @@ wire        r2_c   = alu_stat_wr[0] ? alu_stat[0]          :
                      r2_wr          ? reg_dest_val_in[0]   : r2[0];              // C
 
 wire        r2_z   = alu_stat_wr[1] ? alu_stat[1]          :
+                     crypto_stat_wr ? crypto_stat_z        :
                      r2_wr          ? reg_dest_val_in[1]   : r2[1];              // Z
 
 wire        r2_n   = alu_stat_wr[2] ? alu_stat[2]          :

--- a/core/rtl/verilog/omsp_spm.v
+++ b/core/rtl/verilog/omsp_spm.v
@@ -12,6 +12,7 @@ module omsp_spm(
   input  wire                    eu_mb_en,
   input  wire              [1:0] eu_mb_wr,
   input  wire                    update_spm,
+  input  wire                    cancel_spm,
   input  wire                    enable_spm,
   input  wire                    disable_spm,
   input  wire                    check_new_spm,
@@ -68,25 +69,19 @@ function do_overlap;
   end
 endfunction
 
-initial
-begin
-  public_start = 0;
-  public_end = 0;
-  secret_start = 0;
-  secret_end = 0;
-  enabled = 0;
-end
+`define INIT_SM         \
+    id <= 0;            \
+    public_start <= 0;  \
+    public_end <= 0;    \
+    secret_start <= 0;  \
+    secret_end <= 0;    \
+    enabled <= 0;
 
 always @(posedge mclk or posedge puc_rst)
 begin
   if (puc_rst)
   begin
-    id <= 0;
-    public_start <= 0;
-    public_end <= 0;
-    secret_start <= 0;
-    secret_end <= 0;
-    enabled <= 0;
+    `INIT_SM
   end
   else if (update_spm)
   begin
@@ -100,22 +95,22 @@ begin
         secret_start <= r14;
         secret_end <= r15;
         enabled <= 1;
-        $display("New SM config: %h %h %h %h, %b", r12, r13, r14, r15, |r10);
+        $display("New SM %1d config: %h %h %h %h, %b", next_id, r12, r13, r14, r15, |r10);
       end
       else
       begin
         $display("Invalid SM config: %h %h %h %h, %b", r12, r13, r14, r15, |r10);
       end
     end
-    else if (pc >= public_start && pc < public_end)
+    else if (cancel_spm & key_selected)
     begin
-      id <= 0;
-      public_start <= 0;
-      public_end <= 0;
-      secret_start <= 0;
-      secret_end <= 0;
-      enabled <= 0;
-      $display("SM disabled");
+      `INIT_SM
+      $display("SM %1d cancelled", id);
+    end
+    else if (~cancel_spm & (pc >= public_start && pc < public_end))
+    begin
+      `INIT_SM
+      $display("SM %1d disabled", id);
     end
   end
   else if (key_selected & write_key)

--- a/core/rtl/verilog/omsp_spm.v
+++ b/core/rtl/verilog/omsp_spm.v
@@ -145,9 +145,10 @@ begin
   begin
     if (mem_violation)
     begin
-      $display("mem violation @0x%h, from ", eu_mab);
-      if (handling_irq) $display("IRQ");
-      else              $display("0x%h", pc);
+      if (handling_irq) 
+        $display("mem violation @0x%h from IRQ", eu_mab);
+      else              
+        $display("mem violation @0x%h from 0x%h", eu_mab, pc);
     end
     else if (exec_violation)
       $display("exec violation %h -> %h", prev_pc, pc);

--- a/core/rtl/verilog/omsp_spm_control.v
+++ b/core/rtl/verilog/omsp_spm_control.v
@@ -16,6 +16,7 @@ module omsp_spm_control(
   input  wire                    update_spm,
   input  wire                    enable_spm,
   input  wire                    disable_spm,
+  input  wire                    cancel_spm,
   input  wire                    verify_spm,
   input  wire             [15:0] r10,
   input  wire             [15:0] r12,
@@ -80,6 +81,9 @@ always @(posedge mclk or posedge puc_rst)
     next_id <= 16'h1;
   else if (update_spm && enable_spm)
     next_id <= next_id + 16'h1;
+  else if (update_spm && cancel_spm)
+    /* the ID was never really assigned, so it's safe to reuse it */
+    next_id <= next_id - 16'h1;
 
 assign violation = |spms_violation || (next_id == 16'hfff0);
 assign dma_violation = |spms_dma_violation;
@@ -159,6 +163,7 @@ omsp_spm #(
   .eu_mb_wr             (eu_mb_wr),
   .update_spm           (spms_update),
   .enable_spm           (enable_spm),
+  .cancel_spm           (cancel_spm),
   .disable_spm          (disable_spm),
   .check_new_spm        (spms_check),
   .verify_spm           (verify_spm),

--- a/core/rtl/verilog/openMSP430.v
+++ b/core/rtl/verilog/openMSP430.v
@@ -253,6 +253,7 @@ wire         [15:0] current_inst_pc;
 wire         [15:0] prev_inst_pc;
 wire          [3:0] irq_num;
 wire                irq_detect;
+wire                irq_pnd;
 
 wire                spm_busy;
 wire                spm_violation_eu;
@@ -367,6 +368,7 @@ omsp_frontend frontend_0 (
     .prev_inst_pc (prev_inst_pc),
     .irq_num      (irq_num),
     .irq_detect   (irq_detect),
+    .irq_pnd      (irq_pnd),
 			     
 // INPUTs
     .cpu_en_s     (cpu_en_s),      // Enable CPU code execution (synchronous)
@@ -450,6 +452,7 @@ omsp_execution_unit execution_unit_0 (
     .prev_inst_pc (prev_inst_pc),
     .irq_num      (irq_num),
     .irq_detect   (irq_detect),
+    .irq_pnd      (irq_pnd),
     .dma_addr     (dma_addr)
 );
 

--- a/core/rtl/verilog/openMSP430_defines.v
+++ b/core/rtl/verilog/openMSP430_defines.v
@@ -726,8 +726,9 @@
 `define E_IRQ_PRE   5'h10
 `define E_IRQ_EXT_0 5'h11
 `define E_IRQ_EXT_1 5'h12
-`define E_IRQ_SSA_RD 5'h13
-`define E_IRQ_SP_WR 5'h14
+`define E_IRQ_SSA_RD_1 5'h13
+`define E_IRQ_SSA_RD_2 5'h14
+`define E_IRQ_SP_WR    5'h15
 
 // ALU control signals
 `define ALU_SRC_INV   0

--- a/core/rtl/verilog/openMSP430_defines.v
+++ b/core/rtl/verilog/openMSP430_defines.v
@@ -726,7 +726,7 @@
 `define E_IRQ_PRE   5'h10
 `define E_IRQ_EXT_0 5'h11
 `define E_IRQ_EXT_1 5'h12
-`define E_IRQ_SP_RD 5'h13
+`define E_IRQ_SSA_RD 5'h13
 `define E_IRQ_SP_WR 5'h14
 
 // ALU control signals

--- a/core/sim/rtl_sim/bin/rtlsim.sh
+++ b/core/sim/rtl_sim/bin/rtlsim.sh
@@ -73,7 +73,7 @@ fi
 if [ "${OMSP_SIMULATOR:-iverilog}" = iverilog ]; then
 
     rm -rf simv
-    IVERILOG_CMD="iverilog -Wall -Wno-timescale -Winfloop -o simv -c $3"
+    IVERILOG_CMD="iverilog -o simv -c $3" #-Wall -Wno-timescale -Winfloop 
     NODUMP=${OMSP_NODUMP-0}
     if [ -z "${__SANCUS_SIM}" ]; then
       SIM_FLAG=''

--- a/core/sim/rtl_sim/run/run_all_sancus
+++ b/core/sim/rtl_sim/run/run_all_sancus
@@ -14,6 +14,7 @@ mkdir  ./log
 # Sancus-specific tests
 stdbuf -oL ../bin/msp430sim sancus/sm_eint                 | tee ./log/sancus-sm_eint.log
 stdbuf -oL ../bin/msp430sim sancus/sm_irq                  | tee ./log/sancus-sm_irq.log
+stdbuf -oL ../bin/msp430sim sancus/crypto_irq              | tee ./log/sancus-sm_crypto_irq.log
 stdbuf -oL ../bin/msp430sim sancus/sm_irq_public_end       | tee ./log/sancus-sm_irq_public_end.log
 stdbuf -oL ../bin/msp430sim sancus/sm_irq_exec_violation   | tee ./log/sancus-sm_irq_exec_violation.log
 stdbuf -oL ../bin/msp430sim sancus/sm_irq_mem_violation    | tee ./log/sancus-sm_irq_mem_violation.log

--- a/core/sim/rtl_sim/src/sancus/crypto_irq.s43
+++ b/core/sim/rtl_sim/src/sancus/crypto_irq.s43
@@ -1,0 +1,154 @@
+/*===========================================================================*/
+/*                 INTERRUPTIBLE CRYPTO CORE                                 */
+/*---------------------------------------------------------------------------*/
+/* An IRQ while executing a crypto instruction should fail that instruction. */
+/*                                                                           */
+/*---------------------------------------------------------------------------*/
+/*===========================================================================*/
+
+.include "pmem_defs.asm"
+.include "sancus_macros.asm"
+
+.set unprotected_stack_base, DMEM_240
+.set bar_stack_base, DMEM_260
+
+.set foo_secret_start, DMEM_262
+.set foo_secret_end, DMEM_268
+.set bar_secret_start, foo_secret_end
+.set bar_secret_end, DMEM_26E
+.set bar_sp_save, (bar_secret_end - 4)
+; IRQ logic stores sp at memory location pointed to by last private address
+.set bar_sp_save_loc, (bar_secret_end - 2)
+
+; (un)wrap one word of associated data and plaintext
+.set ad, DMEM_202
+.set ad_end, (ad+2)
+.set body, ad_end
+.set body_end, (body+2)
+.set cipher, body_end
+.set cipher_end, (cipher+2)
+.set tag, cipher_end
+.set ad_val, 0xc0de
+.set body_val, 0xbeef
+
+.global main
+main:
+    disable_wdt
+    eint
+    clr &bar_sp_save
+    mov #unprotected_stack_base, r1
+    mov #ad_val, &ad
+    mov #body_val, &body
+    clr &cipher
+    clr &tag
+    clr &tag+2,
+    clr &tag+4
+    clr &tag+6
+    mov #0x1000, r4
+    clr r4
+        
+    ; === UNPROTECTED SANCUS_ENABLE ===
+    sancus_enable #1234, #bar_public_start, #bar_public_end, #bar_secret_start, #bar_secret_end
+    ; should continue here after IRQ
+    call #bar_public_start
+
+    ; should not come here
+    jmp fail_test
+    
+    /* ----------------------         END OF TEST        --------------- */
+end_of_test:
+	mov #0x2000, r4
+	br #0xffff
+
+fail_test:
+    clr r4
+    br #0xffff
+
+    /* ----------------------         SANCUS MODULE      --------------- */
+
+bar_public_start:
+    mov #bar_sp_save, &bar_sp_save_loc
+    mov &bar_sp_save, r4
+    bit #0x1, r4
+    jz entry_call
+    
+    ; return from interrupt
+    mov r4, r1
+    repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
+    reti
+
+entry_call:
+    mov #bar_stack_base, r1
+    ; === SANCUS_GET_CALLER_ID ===
+    sancus_get_caller_id
+    tst r15
+    jnz fail_test
+
+    ; === PROTECTED SANCUS_ENABLE ===
+    sancus_enable #1234, #foo_public_start, #foo_public_end, #foo_secret_start, #foo_secret_end
+    ; should continue here after IRQ
+
+    ; === SANCUS_GET_ID ===
+    mov #foo_public_start, r15
+    sancus_get_id
+    cmp #2, r15
+    jne fail_test
+    
+    ; === SANCUS_WRAP ===
+    ; #0 -> use SM private HW key
+    sancus_wrap #0, #ad, #ad_end, #body, #body_end, #cipher, #tag
+
+    clr &body
+    mov #0x1000, r4    
+    ; ensure non-zero cipher/tag values
+    tst &cipher
+    jz fail_test
+    tst &tag
+    jz fail_test
+    
+    ; === SANCUS_UNWRAP ===
+    ; #0 -> use SM private HW key
+    sancus_unwrap #0, #ad, #ad_end, #cipher, #cipher_end, #body, #tag 
+    
+    ; ensure tag verification and unwrap(cipher) == plaintext
+    tst r15
+    jz fail_test
+    cmp #body_val, &body
+    jne fail_test
+    br #end_of_test
+bar_public_end:
+
+foo_public_start:
+    ; should not come here
+    br #fail_test
+foo_public_end:
+
+    /* ----------------------      INTERRUPT ROUTINES    --------------- */
+
+IRQ_VECTOR:
+    tst r15
+    jnz 1f
+    repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
+    reti
+1:  mov #unprotected_stack_base, r1
+    do_reti r15
+
+    /* ----------------------         INTERRUPT VECTORS  --------------- */
+
+.section .vectors, "a"
+.word end_of_test  ; Interrupt  0 (lowest priority)    <unused>
+.word end_of_test  ; Interrupt  1                      <unused>
+.word end_of_test  ; Interrupt  2                      <unused>
+.word end_of_test  ; Interrupt  3                      <unused>
+.word end_of_test  ; Interrupt  4                      <unused>
+.word end_of_test  ; Interrupt  5                      <unused>
+.word end_of_test  ; Interrupt  6                      <unused>
+.word end_of_test  ; Interrupt  7                      <unused>
+.word end_of_test  ; Interrupt  8                      <unused>
+.word IRQ_VECTOR   ; Interrupt  9                      TEST IRQ
+.word end_of_test  ; Interrupt 10                      Watchdog timer
+.word end_of_test  ; Interrupt 11                      <unused>
+.word end_of_test  ; Interrupt 12                      <unused>
+.word end_of_test  ; Interrupt 13                      SM_IRQ
+.word end_of_test  ; Interrupt 14                      NMI
+.word main         ; Interrupt 15 (highest priority)   RESET

--- a/core/sim/rtl_sim/src/sancus/crypto_irq.v
+++ b/core/sim/rtl_sim/src/sancus/crypto_irq.v
@@ -1,0 +1,138 @@
+/*===========================================================================*/
+/*                 INTERRUPTIBLE CRYPTO CORE                                 */
+/*---------------------------------------------------------------------------*/
+/* An IRQ while executing a crypto instruction should fail that instruction. */
+/*                                                                           */
+/*---------------------------------------------------------------------------*/
+/*===========================================================================*/
+
+`define LONG_TIMEOUT
+`define IRQ_TIMEOUT         16'd10
+`define NB_IRQS             16'd2
+
+`define AD_MEM              mem202
+`define AD_VAL              16'hc0de
+`define BODY_MEM            mem204
+`define BODY_VAL            16'hbeef
+`define CIPHER_MEM          mem206
+`define TAG_MEM_0           mem208
+`define TAG_MEM_1           mem20A
+`define TAG_MEM_2           mem20C
+`define TAG_MEM_3           mem20E
+
+`define DUMP_WRAP \
+    $display("ad=0x%h; body=0x%h; cipher=0x%h; tag=0x%h/0x%h/0x%h/0x%h", `AD_MEM, `BODY_MEM, `CIPHER_MEM, `TAG_MEM_0, `TAG_MEM_1, `TAG_MEM_2, `TAG_MEM_3);
+
+`define CHK_WRAP(adVal, bodyVal, cipherVal, tag0, tag1, tag2, tag3) \
+      if (`AD_MEM != adVal)         tb_error("====== AD VAL ======"); \
+      if (`BODY_MEM != bodyVal)     tb_error("====== BODY VAL ======"); \
+      if (`CIPHER_MEM != cipherVal) tb_error("====== CIPHER VAL ======"); \
+      if (`TAG_MEM_0 != tag0)       tb_error("====== TAG 0 VAL ======"); \
+      if (`TAG_MEM_1 != tag1)       tb_error("====== TAG 1 VAL ======"); \
+      if (`TAG_MEM_2 != tag2)       tb_error("====== TAG 2 VAL ======"); \
+      if (`TAG_MEM_3 != tag3)       tb_error("====== TAG 3 VAL ======");
+
+`define CHK_RV(r15Val) \
+    if (r2_z) tb_error("====== R2 ZERO FLAG SET ====="); \
+    if (r15!=r15Val) tb_error("====== CRYPTO RETURN VALUE =====");
+
+`define SEND_CRYPTO_IRQ( str, chk_irq, nb, timeout ) \
+    $display({"\n--- IRQ: ", str, " %2d ---"}, nb); \
+    @(posedge crypto_start); \
+    $display("crypto started; sending interrupt in %2d cycles", timeout); \
+    irq_cntdwn = timeout; \
+    while(irq_cntdwn !== 16'd0) begin \
+      irq_cntdwn = irq_cntdwn - 16'd1; \
+      @(posedge mclk); \
+    end \
+    irq[9] = 1; \
+    tsc_val1 = cur_tsc; \
+    while(~handling_irq) @(posedge mclk); \
+    $display("crypto interrupted at 0x%h : \t%s", current_inst_pc, inst_full); \
+    chk_irq \
+    @(posedge handling_irq); \
+    irq[9] = 0; \
+    @(negedge handling_irq); \
+    tsc_val2 = cur_tsc; \
+    repeat(2) @(posedge mclk); \
+    $display("In ISR with reti 0x%h; IRQ latency was %2d", r15, tsc_val2 - tsc_val1);
+
+`define PASS_CRYPTO( str ) \
+    $display({"\n--- PASS: ", str, " ---"}); \
+    @(posedge crypto_start); \
+    @(posedge exec_done); \
+    $display("crypto passed at 0x%h : \t%s", current_inst_pc, inst_full); \
+    if (r2_z)  tb_error("====== R2 ZERO FLAG SET ====="); \
+    repeat(2) @(posedge mclk);
+
+`define INTERRUPT_CRYPTO( str, chk_irq, chk_final ) \
+    nb = `NB_IRQS; \
+    while(nb !== 16'd0) begin \
+        `SEND_CRYPTO_IRQ( str, chk_irq, nb, `IRQ_TIMEOUT ) \
+        nb = nb - 16'd1; \
+    end \
+    `PASS_CRYPTO( str ) \
+    chk_final
+
+`define CHK_NOT_ENABLED( sm_en) \
+    if (~r2_z) tb_error("====== R2 ZERO FLAG NOT SET ====="); \
+    if (sm_en) tb_error("====== SM ENABLED TOO EARLY ====="); \
+    if (r15!=0) tb_error("====== SANCUS_ENABLE RETURN VALUE =====");
+    
+`define CHK_ENABLED( sm_en, sm_id, sm_id_val ) \
+    if (~sm_en)             tb_error("====== SM FINAL NOT ENABLED ====="); \
+    if (r15!=sm_id)         tb_error("====== SANCUS_ENABLE FINAL RETURN VALUE ====="); \
+    if (sm_id!=sm_id_val)   tb_error("====== SM FINAL ID VALUE =====");
+
+reg [15:0] irq_cntdwn;
+reg [15:0] nb;
+
+reg [15:0] cipherVal;
+reg [15:0] tagVal_0;
+reg [15:0] tagVal_1;
+reg [15:0] tagVal_2;
+reg [15:0] tagVal_3;
+
+reg [63:0] tsc_val1;
+reg [63:0] tsc_val2;
+initial
+   begin
+      $display(" ===============================================");
+      $display("|                 START SIMULATION              |");
+      $display(" ===============================================");
+      repeat(5) @(posedge mclk);
+      stimulus_done = 0;
+      tsc_val1 <= 0;
+      tsc_val2 <= 0;
+
+      @(r4==16'h1000);
+      `CHK_WRAP(`AD_VAL, `BODY_VAL, 16'h0, 16'h0, 16'h0, 16'h0, 16'h0)
+      `DUMP_WRAP
+      
+      `INTERRUPT_CRYPTO("UNPROTECTED ENABLE", `CHK_NOT_ENABLED(sm_0_enabled), `CHK_ENABLED(sm_0_enabled, sm_0_id, 1))
+
+      `SEND_CRYPTO_IRQ( "CALLER ID" ,`CHK_RV(0), 0, 1)
+
+      `INTERRUPT_CRYPTO("PROTECTED ENABLE", `CHK_NOT_ENABLED(sm_1_enabled), `CHK_ENABLED(sm_1_enabled, sm_1_id, 2))
+
+      `SEND_CRYPTO_IRQ( "GET ID" ,`CHK_RV(2), 0, 1)
+
+      `CHK_WRAP(`AD_VAL, `BODY_VAL, 16'h0, 16'h0, 16'h0, 16'h0, 16'h0)
+      `INTERRUPT_CRYPTO("SANCUS WRAP", `CHK_WRAP(`AD_VAL, `BODY_VAL, `CIPHER_MEM, `TAG_MEM_0, `TAG_MEM_1, `TAG_MEM_2, `TAG_MEM_3), )
+      cipherVal = `CIPHER_MEM;
+      tagVal_0 = `TAG_MEM_0;
+      tagVal_1 = `TAG_MEM_1;
+      tagVal_2 = `TAG_MEM_2;
+      tagVal_3 = `TAG_MEM_3;
+      @(r4==16'h1000);
+      `DUMP_WRAP
+      
+      `INTERRUPT_CRYPTO("SANCUS UNWRAP",
+        `CHK_WRAP(`AD_VAL, `BODY_MEM, cipherVal, tagVal_0, tagVal_1, tagVal_2, tagVal_3),
+        `CHK_WRAP(`AD_VAL, `BODY_VAL, cipherVal, tagVal_0, tagVal_1, tagVal_2, tagVal_3))
+      `DUMP_WRAP
+      
+      /* ----------------------  END OF TEST ---------------- */
+      @(r4==16'h2000);
+      stimulus_done = 1;
+   end

--- a/core/sim/rtl_sim/src/sancus/crypto_irq.v
+++ b/core/sim/rtl_sim/src/sancus/crypto_irq.v
@@ -100,6 +100,11 @@ initial
       $display(" ===============================================");
       $display("|                 START SIMULATION              |");
       $display(" ===============================================");
+
+`ifndef UNPROTECTED_IRQ_REG_PUSH
+`define UNPROTECTED_IRQ_REG_PUSH
+`endif
+
       repeat(5) @(posedge mclk);
       stimulus_done = 0;
       tsc_val1 <= 0;

--- a/core/sim/rtl_sim/src/sancus/sancus_macros.asm
+++ b/core/sim/rtl_sim/src/sancus/sancus_macros.asm
@@ -3,17 +3,20 @@
 ; return callerID in r15
 .macro sancus_get_caller_id
     .word 0x1387
+1:  jz 1b /* should never fail */
 .endm
 
 ; return ID of SM @r15 in r15
 .macro sancus_get_id
     .word 0x1386
+1:  jz 1b /* should never fail */
 .endm
 
 ; set stack overflow guard address (0x0 to disable); clobbers r15
 .macro sancus_stack_guard addr:req
     mov \addr, r15
     .word 0x1388
+1:  jz 1b /* should never fail */
 .endm
 
 .macro sancus_enable vendor:req, ps:req, pe:req, ss:req, se:req
@@ -23,16 +26,33 @@
     mov \ps, r12
     mov \pe, r13
     mov \ss, r14
-    mov \se, r15
+1:  mov \se, r15
     .word 0x1381
+    jz 1b /* restart on IRQ */
 .endm
 
-.macro sancus_wrap
+.macro sancus_wrap key:req, ad:req, ad_end:req, body:req, body_end:req, cipher:req, tag:req
+    mov \key, r9
+    mov \ad, r10
+    mov \ad_end, r11
+    mov \body, r12
+    mov \body_end, r13
+    mov \cipher, r14
+1:  mov \tag, r15
     .word 0x1384
+    jz 1b /* restart on IRQ */
 .endm
 
-.macro sancus_unwrap
+.macro sancus_unwrap key:req, ad:req, ad_end:req, cipher:req, cipher_end:req, body:req, tag:req
+    mov \key, r9
+    mov \ad, r10
+    mov \ad_end, r11
+    mov \cipher, r12
+    mov \cipher_end, r13
+    mov \body, r14
+1:  mov \tag, r15
     .word 0x1385
+    jz 1b /* restart on IRQ */
 .endm
 
 ; TODO should take continuation argument

--- a/core/sim/rtl_sim/src/sancus/sancus_macros.asm
+++ b/core/sim/rtl_sim/src/sancus/sancus_macros.asm
@@ -3,20 +3,19 @@
 ; return callerID in r15
 .macro sancus_get_caller_id
     .word 0x1387
-1:  jz 1b /* should never fail */
+    jz . /* should never fail */
 .endm
 
 ; return ID of SM @r15 in r15
 .macro sancus_get_id
     .word 0x1386
-1:  jz 1b /* should never fail */
+    jz . /* should never fail */
 .endm
 
 ; set stack overflow guard address (0x0 to disable); clobbers r15
 .macro sancus_stack_guard addr:req
     mov \addr, r15
     .word 0x1388
-1:  jz 1b /* should never fail */
 .endm
 
 .macro sancus_enable vendor:req, ps:req, pe:req, ss:req, se:req
@@ -26,9 +25,10 @@
     mov \ps, r12
     mov \pe, r13
     mov \ss, r14
-1:  mov \se, r15
+1\@:
+    mov \se, r15
     .word 0x1381
-    jz 1b /* restart on IRQ */
+    jz 1\@b /* restart on IRQ */
 .endm
 
 .macro sancus_wrap key:req, ad:req, ad_end:req, body:req, body_end:req, cipher:req, tag:req
@@ -38,9 +38,10 @@
     mov \body, r12
     mov \body_end, r13
     mov \cipher, r14
-1:  mov \tag, r15
+1\@:
+    mov \tag, r15
     .word 0x1384
-    jz 1b /* restart on IRQ */
+    jz 1\@b /* restart on IRQ */
 .endm
 
 .macro sancus_unwrap key:req, ad:req, ad_end:req, cipher:req, cipher_end:req, body:req, tag:req
@@ -50,9 +51,10 @@
     mov \cipher, r12
     mov \cipher_end, r13
     mov \body, r14
-1:  mov \tag, r15
+1\@:
+    mov \tag, r15
     .word 0x1385
-    jz 1b /* restart on IRQ */
+    jz 1\@b /* restart on IRQ */
 .endm
 
 ; TODO should take continuation argument

--- a/core/sim/rtl_sim/src/sancus/sm_foo_gadgets.asm
+++ b/core/sim/rtl_sim/src/sancus/sm_foo_gadgets.asm
@@ -45,7 +45,7 @@ foo_gadget_wr:
     mov r4, &foo_private_data
 	br #end_of_test
 foo_gadget_wrap:
-    sancus_wrap
+    .word 0x1384
     br #end_of_test
 foo_gadget_disable:
     sancus_disable #end_of_test

--- a/core/sim/rtl_sim/src/sancus/sm_irq.s43
+++ b/core/sim/rtl_sim/src/sancus/sm_irq.s43
@@ -10,15 +10,15 @@
 .include "sancus_macros.asm"
 
 .set unprotected_stack_base, DMEM_20F
-.set stack_base, DMEM_260
+.set stack_base, DMEM_240
 .set reg_offset, 0x1234
 .set clobber_val, 0xf00d
 .set tst_val, 0xbabe
 .set tst_addr, DMEM_200
-.set sm_secret_start, DMEM_262
+.set sm_secret_start, DMEM_230
 .set sm_secret_end, DMEM_26E
-.set sm_sp_save_loc,(sm_secret_end - 2)
-.set sm_sp_save, (sm_secret_end - 4)
+.set sm_ssa_loc,(sm_secret_end - 2)
+.set sm_ssa, (sm_secret_end - 4)
 .set do_exit, sm_secret_end ; end boundary is exclusive
 
 .global main
@@ -43,27 +43,31 @@ cont_test:
 
     /* ----------------------         END OF TEST        --------------- */
 end_of_test:
-	mov #0x2000, r15
-	clr r15
-	br #0xffff
+    mov #0x2000, r15
+    clr r15
+    br #0xffff
 
 
     /* ----------------------         SANCUS MODULE      --------------- */
 sm_public_start:
-    mov #sm_sp_save, &sm_sp_save_loc
+    mov #sm_ssa, &sm_ssa_loc
     cmp #0xffff, r4
     jne init_regs
 
     ; restore interrupted execution context
-    mov &sm_sp_save, r1
-    clr &sm_sp_save
-    repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
-    reti
+    mov #sm_ssa-2, r15
+    mov #sm_ssa-4, r14
+
+    mov #sm_ssa-30, r1
+    repeat pop, r2, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
+    mov &sm_ssa, r1
+    clr &sm_ssa
+    br &sm_ssa-2
 
 init_regs:
     ; initialize registers with known values
-    clr &sm_sp_save
-   	mov #stack_base, r1
+    clr &sm_ssa
+    mov #stack_base, r1
     mov #reg_offset+0x4, r4
     mov #reg_offset+0x5, r5
     mov #reg_offset+0x6, r6

--- a/core/sim/rtl_sim/src/sancus/sm_irq.s43
+++ b/core/sim/rtl_sim/src/sancus/sm_irq.s43
@@ -15,7 +15,7 @@
 .set clobber_val, 0xf00d
 .set tst_val, 0xbabe
 .set tst_addr, DMEM_200
-.set sm_secret_start, DMEM_230
+.set sm_secret_start, DMEM_242
 .set sm_secret_end, DMEM_26E
 .set sm_ssa_loc,(sm_secret_end - 2)
 .set sm_ssa, (sm_secret_end - 4)
@@ -55,14 +55,11 @@ sm_public_start:
     jne init_regs
 
     ; restore interrupted execution context
-    mov #sm_ssa-2, r15
-    mov #sm_ssa-4, r14
-
-    mov #sm_ssa-30, r1
-    repeat pop, r2, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
-    mov &sm_ssa, r1
-    clr &sm_ssa
-    br &sm_ssa-2
+    mov #sm_ssa-28, r1
+    repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r2
+    mov &sm_ssa-2, r1
+    ;clr &sm_ssa-2
+    br &sm_ssa
 
 init_regs:
     ; initialize registers with known values
@@ -96,17 +93,19 @@ IRQ_VECTOR:
     ; dummy instruction with two extension words for testing purposes
     mov #tst_val, &tst_addr
     clr &tst_addr
-    repeat_to mov, #clobber_val, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14
 
     tst r1  ; SM interrupted ?
     jnz 1f
+    ; Only clobber if we interrupted an SM as non-SMs have their registers not pushed automatically
+    repeat_to mov, #clobber_val, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14
+    
     mov #0xffff, r4
     mov #2, &do_exit
     mov #unprotected_stack_base, r1
     do_reti r15
 
 1:  mov #1, &do_exit
-    repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
+    ; repeat pop, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15    
     reti
 
     /* ----------------------         INTERRUPT VECTORS  --------------- */

--- a/core/sim/rtl_sim/src/sancus/sm_irq.v
+++ b/core/sim/rtl_sim/src/sancus/sm_irq.v
@@ -12,7 +12,7 @@
 `define STACK_IRQ_INTERRUPTED   (`STACK_IRQ | 16'h1)
 
 `define SM_SP_ADDR              (mem26C)
-`define SM_SP_SAVE              (mem26A)
+`define SM_SP_SAVE              (mem268)
 `define SM_SP_SAVE_LOC          (16'h26A)
 `define TST_MEM                 (mem200)
 `define TST_VAL                 (16'hbabe)
@@ -32,7 +32,7 @@ initial
 // TODO with the SSA frame we cannot support this option anymore and should
 // get rid of all ifdefs in the code base
 `undef UNPROTECTED_IRQ_REG_PUSH
-
+`define LONG_TIMEOUT
       repeat(5) @(posedge mclk);
       stimulus_done = 0;
       saved_pc <= 0;
@@ -65,7 +65,7 @@ initial
       repeat(2) @(posedge mclk);
       $display("IRQ logic done: %d cycles", tsc_val2 - tsc_val1);
       if (r2!==`IRQ_UNPR_STATUS)    tb_error("====== UNPROTECTED IRQ SR ======");
-      `CHK_IRQ_STACK("after unprotected irq", saved_pc, saved_sr)
+      `CHK_IRQ_STACK_UNPROTECTED("after unprotected irq", saved_pc, saved_sr)
       if (`SM_SP_SAVE!==16'h0)      tb_error("====== UNPROTECTED IRQ SP WRITE ======");
       @(`TST_MEM);
       if(`TST_MEM!==`TST_VAL)       tb_error("====== ISR INSTR TWO EXT WORDS ======");

--- a/core/sim/rtl_sim/src/sancus/sm_irq.v
+++ b/core/sim/rtl_sim/src/sancus/sm_irq.v
@@ -7,10 +7,9 @@
 /*===========================================================================*/
 //`define LONG_TIMEOUT
 
-`define STACK_BASE              (`PER_SIZE + 'h60)
-`define STACK_IRQ               (`STACK_BASE - 16'd28)
+`define STACK_BASE              (16'h240) //`PER_SIZE + 'h60)
+`define STACK_IRQ               (`STACK_BASE) //- 16'd28)
 `define STACK_IRQ_INTERRUPTED   (`STACK_IRQ | 16'h1)
-`define STACK_RETI              (`STACK_BASE - 16'd4)
 
 `define SM_SP_ADDR              (mem26C)
 `define SM_SP_SAVE              (mem26A)
@@ -30,9 +29,9 @@ initial
       $display("|                 START SIMULATION              |");
       $display(" ===============================================");
 
-`ifndef UNPROTECTED_IRQ_REG_PUSH
-`define UNPROTECTED_IRQ_REG_PUSH
-`endif
+// TODO with the SSA frame we cannot support this option anymore and should
+// get rid of all ifdefs in the code base
+`undef UNPROTECTED_IRQ_REG_PUSH
 
       repeat(5) @(posedge mclk);
       stimulus_done = 0;


### PR DESCRIPTION
This PR adds support for interruptible crypto operations (in an abandon-and-restart fashion) + use SSA memory pointer for enclave register content instead of enclave stack.

Still needs to be done before merging:

- [ ] remove [UNPROTECTED_IRQ_REG_PUSH](https://github.com/sancus-tee/sancus-core/search?q=UNPROTECTED_IRQ_REG_PUSH&type=Code) from the code base
- [ ] fix failing test cases in `run_all_sancus` (likely changing the asm stubs to the new SSA convention)
- [ ] update linker to the new SSA convention
- [ ] update trusted runtime (sm_entry.S) to the new SSA convention
- [ ] update sm_support to the new interruptible crypto HW contract
- [ ] disable HW support for confidential loading (not compat w interruptible crypto)
