### PR TITLE
Refinements to the DMA attacks

### DIFF
--- a/core/rtl/verilog/periph/dma_attacker.v
+++ b/core/rtl/verilog/periph/dma_attacker.v
@@ -37,16 +37,19 @@ input              dma_ready;       // DMA ready
 // 1)  PARAMETER DECLARATION
 //=============================================================================
 
+parameter              CAPTURE_LENGTH = 16'd2048;
+
 // Register base address (must be aligned to decoder bit width)
 parameter       [14:0] BASE_ADDR   = 15'h0070;
 
 // Decoder bit width (defines how many bits are considered for address decoding)
-parameter              DEC_WD      =  3;
+parameter              DEC_WD      =  4;
 
 // Register addresses offset
-parameter [DEC_WD-1:0] DMA_PER_ADDR  =  'h0,
-                       DMA_PER_CNT   =  'h2,
-                       DMA_PER_TRACE =  'h4;
+parameter [DEC_WD-1:0] DMA_PER_ADDR         = 'h0,
+                       DMA_PER_CNT          = 'h2,
+                       DMA_PER_TRACE        = 'h4,
+                       DMA_PER_TRACE_OFFSET = 'h6;
 
 
 // Register one-hot decoder utilities
@@ -54,9 +57,10 @@ parameter              DEC_SZ      =  (1 << DEC_WD);
 parameter [DEC_SZ-1:0] BASE_REG    =  {{DEC_SZ-1{1'b0}}, 1'b1};
 
 // Register one-hot decoder
-parameter [DEC_SZ-1:0] DMA_PER_ADDR_D  = (BASE_REG << DMA_PER_ADDR),
-                       DMA_PER_CNT_D   = (BASE_REG << DMA_PER_CNT),
-                       DMA_PER_TRACE_D = (BASE_REG << DMA_PER_TRACE);
+parameter [DEC_SZ-1:0] DMA_PER_ADDR_D         = (BASE_REG << DMA_PER_ADDR),
+                       DMA_PER_CNT_D          = (BASE_REG << DMA_PER_CNT),
+                       DMA_PER_TRACE_D        = (BASE_REG << DMA_PER_TRACE),
+                       DMA_PER_TRACE_OFFSET_D = (BASE_REG << DMA_PER_TRACE_OFFSET);
 
 
 //============================================================================
@@ -70,9 +74,10 @@ wire              reg_sel   =  per_en & (per_addr[13:DEC_WD-1]==BASE_ADDR[14:DEC
 wire [DEC_WD-1:0] reg_addr  =  {per_addr[DEC_WD-2:0], 1'b0};
 
 // Register address decode
-wire [DEC_SZ-1:0] reg_dec      = (DMA_PER_ADDR_D   &  {DEC_SZ{(reg_addr==DMA_PER_ADDR)}}) |
-                                 (DMA_PER_CNT_D    &  {DEC_SZ{(reg_addr==DMA_PER_CNT)}}) |
-                                 (DMA_PER_TRACE_D  &  {DEC_SZ{(reg_addr==DMA_PER_TRACE)}});
+wire [DEC_SZ-1:0] reg_dec      = (DMA_PER_ADDR_D          &  {DEC_SZ{(reg_addr==DMA_PER_ADDR)}}) |
+                                 (DMA_PER_CNT_D           &  {DEC_SZ{(reg_addr==DMA_PER_CNT)}}) |
+                                 (DMA_PER_TRACE_D         &  {DEC_SZ{(reg_addr==DMA_PER_TRACE)}}) |
+                                 (DMA_PER_TRACE_OFFSET_D  &  {DEC_SZ{(reg_addr==DMA_PER_TRACE_OFFSET)}});
 
 // Read/Write probes
 wire              reg_write =  |per_we & reg_sel;
@@ -97,41 +102,50 @@ always @ (posedge mclk or posedge puc_rst)
   if (puc_rst)        dma_per_addr <=  16'h00;
   else if (dma_per_addr_wr) dma_per_addr <=  per_din;
 
+reg [15:0] dma_trace_offset = 16'h0;
+reg [15:0] dma_trace_output = 16'h0;
+
+always @ (posedge mclk or posedge puc_rst) begin
+  dma_trace_output <= dma_per_trace[dma_trace_offset +: 16];
+  if (puc_rst)        dma_trace_offset <=  16'h00;
+  else if (reg_wr[DMA_PER_TRACE_OFFSET]) dma_trace_offset <=  per_din;
+end
+
 // DMA_PER_CNT Register
 //-----------------
 reg  [15:0] dma_per_cnt;
 
 wire        dma_per_cnt_wr = reg_wr[DMA_PER_CNT];
 
-reg  [15:0] dma_per_trace = 16'h0;
+reg  [CAPTURE_LENGTH-1:0] dma_per_trace = 0;
 
-wire [15:0] per_dout = |reg_rd ? dma_per_trace : 16'h0;
+wire [15:0] per_dout = |reg_rd ? dma_trace_output : 16'h0;
 
 reg  [15:1] dma_addr = 15'h0;
 reg         dma_en   = 1'b0;
 reg   [1:0] dma_we   = 2'b00;
 
-reg [3:0] internal_cnt = 4'h0;
+reg [15:0] internal_cnt = 0;
 
 always @ (posedge mclk or posedge puc_rst)
-  if (puc_rst)        dma_per_cnt <=  16'h00;
+  if (puc_rst)        dma_per_cnt <=  16'hFFFF;
   else if (dma_per_cnt_wr) dma_per_cnt <=  per_din;
   else begin
     case (dma_per_cnt)
       16'h0: begin
-          dma_per_trace <= {dma_per_trace[14:0], ~dma_ready};
+          dma_per_trace[CAPTURE_LENGTH - 1 - internal_cnt] <= ~dma_ready;
           dma_en <= 1'b1;
-          dma_addr <= dma_per_addr[14:0];
-          internal_cnt <= internal_cnt - 4'h1;
-          if (internal_cnt == 4'h0) begin
+          dma_addr <= dma_per_addr[15:1];
+          internal_cnt <= internal_cnt - 1;
+          if (internal_cnt == 0) begin
             dma_en <= 1'b0;
             dma_per_cnt <= 16'hFFFF;
           end
         end
       16'h1: begin
           dma_en <= 1'b1;
-          dma_addr <= dma_per_addr[14:0];
-          internal_cnt <= 8'd15;
+          dma_addr <= dma_per_addr[15:1];
+          internal_cnt <= CAPTURE_LENGTH - 1;
           dma_per_cnt <= dma_per_cnt - 16'h1;
         end
       16'hFFFF: begin

--- a/core/sim/rtl_sim/run/run
+++ b/core/sim/rtl_sim/run/run
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+cd "$parent_path"
+
 # Enable/Disable waveform dumping
 OMSP_NODUMP=0
 export OMSP_NODUMP

--- a/core/sim/rtl_sim/src/sancus/dma_covert.s43
+++ b/core/sim/rtl_sim/src/sancus/dma_covert.s43
@@ -1,0 +1,69 @@
+.include "pmem_defs.asm"
+.include "sancus_macros.asm"
+
+.set MMIO_ADDR, (0x0090)
+.set DMEM_ADDR, DMEM_200
+.set STACK, DMEM_240
+.set PMEM_ADDR, end_of_test
+
+.global main
+main:
+    clr r15
+
+; starting address: r10
+    mov #mydata, r10
+; number of words: r11
+    mov #4, r11
+; word counter: r12
+    mov #0, r12
+
+wordswitch:
+; word to transmit: r5
+    mov 0(r10), r5
+; bit counter: r8
+    mov #0x10, r8
+bitswitch:
+    mov r5, r6
+    and #1, r6
+    jz true
+    mov &DMEM_ADDR, r3
+true:
+    dec r8
+    rra r5
+    cmp #0, r8
+    jne bitswitch
+
+    inc r12
+    add #2, r10
+    cmp r11, r12
+    jne wordswitch
+
+
+    /* ----------------------         END OF TEST        --------------- */
+end_of_test:
+	mov #0x2000, r15
+    br #0xffff
+
+mydata:
+    .word 0xdead
+    .word 0xbeef
+    .word 0xcafe
+    .word 0xbabe
+
+.section .vectors, "a"
+.word end_of_test  ; Interrupt  0 (lowest priority)    <unused>
+.word end_of_test  ; Interrupt  1                      <unused>
+.word end_of_test  ; Interrupt  2                      <unused>
+.word end_of_test  ; Interrupt  3                      <unused>
+.word end_of_test  ; Interrupt  4                      <unused>
+.word end_of_test  ; Interrupt  5                      <unused>
+.word end_of_test  ; Interrupt  6                      <unused>
+.word end_of_test  ; Interrupt  7                      <unused>
+.word end_of_test  ; Interrupt  8                      <unused>
+.word end_of_test  ; Interrupt  9                      TEST IRQ
+.word end_of_test  ; Interrupt 10                      Watchdog timer
+.word end_of_test  ; Interrupt 11                      <unused>
+.word end_of_test  ; Interrupt 12                      <unused>
+.word end_of_test  ; Interrupt 13                      SM_IRQ
+.word end_of_test  ; Interrupt 14                      NMI
+.word main         ; Interrupt 15 (highest priority)   RESET

--- a/core/sim/rtl_sim/src/sancus/dma_covert.v
+++ b/core/sim/rtl_sim/src/sancus/dma_covert.v
@@ -1,0 +1,19 @@
+initial
+   begin
+      $display("===============================================");
+      $display("                 START SIMULATION             |");
+      $display("===============================================");
+      #10;
+
+      repeat(5) @(posedge mclk);
+      stimulus_done <= 0;
+
+      /* ----------------------  INITIALIZATION --------------- */
+
+      $display("waiting for end of test...");
+
+      /* ----------------------  END OF TEST --------------- */
+      @(r15==16'h2000);
+
+      stimulus_done <= 1;
+   end

--- a/core/sim/rtl_sim/src/sancus/sm_dma_peripheral.s43
+++ b/core/sim/rtl_sim/src/sancus/sm_dma_peripheral.s43
@@ -7,6 +7,7 @@
 .set dma_addr, (0x0070)
 .set dma_cnt, (0x0072)
 .set dma_trace, (0x0074)
+.set dma_offset, (0x0076)
 
 ; This enclave accepts a guess for a passcode in the r6 register. It also has a
 ; counter to log the number of incorrect guesses.

--- a/core/sim/rtl_sim/src/sancus/sm_dma_peripheral.v
+++ b/core/sim/rtl_sim/src/sancus/sm_dma_peripheral.v
@@ -16,9 +16,9 @@ initial
       /* ----------------------  END OF TEST --------------- */
       @(r15==16'h2000);
 
-      if(r8 !== 16'b0000000001000000)
+      if(r8 !== 16'b0000001000000000)
          tb_error("====== r8 does not mach expected value ======");
-      if(r9 !== 16'b0000000101000000)
+      if(r9 !== 16'b0000001010000000)
          tb_error("====== r9 does not mach expected value ======");
 
       stimulus_done = 1;


### PR DESCRIPTION
- DMA attacker peripheral can now be configured in the length of the captured trace (allowing to capture more than 16 cycles at a time)
- Add a test case demonstrating the use of the DMA-based leakage as a covert channel