### PR TITLE
Changes to the crypto unit state machine: added register ensuring constant-time execution

### DIFF
--- a/core/rtl/verilog/crypto/crypto_control.v
+++ b/core/rtl/verilog/crypto/crypto_control.v
@@ -169,8 +169,9 @@ always @(*)
         WRITE_TAG:         next_state =               WRITE_TAG_WAIT;
         WRITE_TAG_WAIT:    next_state = wrap_busy   ? WRITE_TAG_WAIT    :
                                         mem_done    ? SUCCESS           : WRITE_TAG;
-        VERIFY_TAG:        next_state = tag_ok      ? VERIFY_TAG_WAIT   : FAIL;
-        VERIFY_TAG_WAIT:   next_state = mem_done    ? SUCCESS           :
+        VERIFY_TAG:        next_state = VERIFY_TAG_WAIT;
+        VERIFY_TAG_WAIT:   next_state = mem_done    ? 
+                                        (tag_ok_reg  ? SUCCESS           : FAIL) :
                                         wrap_busy   ? VERIFY_TAG_WAIT   : VERIFY_TAG;
         GEN_VKEY_INIT:     next_state =               WRAP_VID;
         WRAP_VID:          next_state =               WRAP_VID_WAIT;
@@ -250,6 +251,7 @@ reg        wrap_data_empty;
 reg [15:0] wrap_data_in_val;
 reg        update_wrap_data_in;
 reg        set_wrap_start_continue;
+reg        tag_ok_reg_init;
 
 always @(*)
 begin
@@ -285,6 +287,7 @@ begin
     stat_z = 0;
     stat_wr = 0;
     sm_cancel = 0;
+    tag_ok_reg_init = 0;
 
     case (next_state)
         IDLE:
@@ -374,6 +377,7 @@ begin
             mab_ctr_base = r15;
             mab_ctr_limit_init = 1;
             mab_ctr_limit = r15 + `SECURITY / 8;
+            tag_ok_reg_init = 1;
         end
 
         WRITE_TAG:
@@ -782,6 +786,14 @@ always @(posedge clk)
 
 // signal to indicate if the tag matches with the memory contents
 wire tag_ok = wrap_data_out_ready ? (wrap_data_out == mem_in) : 1;
+reg tag_ok_reg;
+always @(posedge clk)
+    if (tag_ok_reg_init)
+        tag_ok_reg = 1;
+    else if ( !tag_ok )
+        tag_ok_reg = 0;
+// always @(negedge tag_ok)
+//     tag_ok_reg = 0;
 
 reg [KEY_IDX_SIZE-1:0] key_ctr;
 reg                    key_ctr_reset;

--- a/core/rtl/verilog/crypto/crypto_control.v
+++ b/core/rtl/verilog/crypto/crypto_control.v
@@ -220,9 +220,10 @@ always @(*)
         DEC_WAIT:          next_state = wrap_busy   ? DEC_WAIT          :
                                         mem_done    ? DEC_TAG_INIT      : DEC;
         DEC_TAG_INIT:      next_state =               DEC_TAG_WAIT;
-        DEC_TAG:           next_state = tag_ok      ? DEC_TAG_WAIT      : FAIL;
-        DEC_TAG_WAIT:      next_state = mem_done    ? GEN_SMKEY_INIT_PS :
-                                        wrap_busy   ? DEC_TAG_WAIT      : DEC_TAG;
+        DEC_TAG:           next_state = DEC_TAG_WAIT;
+        DEC_TAG_WAIT:      next_state = mem_done    ? 
+                                        (tag_ok_reg  ? GEN_SMKEY_INIT_PS           : FAIL) :
+                                        wrap_busy   ? DEC_TAG_WAIT   : DEC_TAG;
         CLEAR_CODE_INIT1:  next_state =               CLEAR_CODE_INIT2;
         CLEAR_CODE_INIT2:  next_state =               CLEAR_CODE;
         CLEAR_CODE:        next_state = mem_done    ? CLEAR_DATA_INIT1  : CLEAR_CODE;
@@ -632,6 +633,7 @@ begin
             mab_ctr_base = r9;
             mab_ctr_limit_init = 1;
             mab_ctr_limit = r9 + `SECURITY/8;
+            tag_ok_reg_init = 1;
         end
 
         DEC_TAG:


### PR DESCRIPTION
See write up for full explanation.
The cryptographic unit uses comparison in hardware to check the tag of sancus_unwrap. The state machine used for this verification process leaks information through a timing side-channel. 
To addres this issue, I have made the comparison constant time by adding a register to keep track of the result of the comparison!
Other solution considered: adding dummy states.
[pullrequest.pdf](https://github.com/user-attachments/files/18218622/pullrequest.pdf)
